### PR TITLE
Update schema to comply with new split content types

### DIFF
--- a/.meshrc.yaml
+++ b/.meshrc.yaml
@@ -14,23 +14,6 @@ sources:
     handler:
       graphql:
         endpoint: "{env.MEDIA_SERVICE_URL}"
-additionalTypeDefs: |
-  extend type Chapter {
-    contents: [Content!]! @resolveTo(
-      sourceName: "ContentService",
-      sourceTypeName: "Query",
-      sourceFieldName: "contentsByChapterIds",
-      keyField: "id",
-      keysArg: "chapterIds"
-    )
-  }
-  extend type Content {
-    mediaRecords: [MediaRecord!]! @resolveTo(
-      sourceName: "MediaService",
-      sourceTypeName: "Query",
-      sourceFieldName: "mediaRecordsByContentIds",
-      keyField: "id",
-      keysArg: "contentIds"
-    )
-  }
+additionalTypeDefs:
+  - "./additionalTypeDefs/content.graphqls"
 additionalEnvelopPlugins: "./envelopPlugins"

--- a/additionalTypeDefs/content.graphqls
+++ b/additionalTypeDefs/content.graphqls
@@ -1,0 +1,19 @@
+extend type Chapter {
+  contents: [Content!]! @resolveTo(
+    sourceName: "ContentService",
+    sourceTypeName: "Query",
+    sourceFieldName: "contentsByChapterIds",
+    keyField: "id",
+    keysArg: "chapterIds"
+  )
+}
+
+extend type MediaContent {
+  mediaRecords: [MediaRecord!]! @resolveTo(
+    sourceName: "MediaService",
+    sourceTypeName: "Query",
+    sourceFieldName: "mediaRecordsByContentIds",
+    keyField: "id",
+    keysArg: "contentIds"
+  )
+}


### PR DESCRIPTION
Closes IT-REX-Platform/content_service#12

## Description of changes
Updated the gateway's schema to comply with the new split content types implemented in https://github.com/IT-REX-Platform/content_service/pull/16

  
## How has this been tested?
Please describe the test strategy you followed.

- [ ] automated unit test
- [ ] automated integration test
- [ ] automated acceptance test
- [x] manual, exploratory test

Tested out the one query this change affects (getting `Contents`)
    
## Checklist before requesting a review
- [x] My code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My code fulfills all acceptance criteria
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [ ] I have made corresponding changes to the documentation
- [ ] I have added explanation of architectural decision and rationales to [wiki/adr](https://github.com/IT-REX-Platform/wiki/tree/main/adr)
- [ ] I have updated the changes in the ticket description

## Checklist for reviewer
- [ ] The code works and does not throw errors
- [ ] The code is easy to understand and there are no confusing parts
- [ ] The code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] The code change accomplishes what it is supposed to do
- [ ] I cannot think of any use case in which the code does not behave as intended
- [ ] The added and existing tests reasonably cover the code change
- [ ] I cannot think of any test cases, input or edge cases that should be tested in addition
- [ ] Description of the change is included in the documentation
