### PR TITLE
switch associated contents to non-throwing query

### DIFF
--- a/additionalTypeDefs/rewards.graphqls
+++ b/additionalTypeDefs/rewards.graphqls
@@ -9,11 +9,11 @@ extend type ScoreboardItem {
 }
 
 extend type RewardLogItem {
-  associatedContents: [Content!]! @resolveTo(
-    sourceName: "ContentService",
-    sourceTypeName: "Query",
-    sourceFieldName: "contentsByIds",
-    keyField: "associatedContentIds",
-    keysArg: "ids"
+  associatedContents: [Content]! @resolveTo(
+      sourceName: "ContentService",
+      sourceTypeName: "Query",
+      sourceFieldName: "findContentsByIds",
+      keyField: "associatedContentIds",
+      keysArg: "ids"
   )
 }


### PR DESCRIPTION
## Description of changes
Use the non-throwing query of the content service. Only merge together with the pull request in the content service. Detailed description is there.

  
## How has this been tested?
I haven't tested it yet because I had some trouble with the local backend and no time to check what's the problem.
    
## Checklist before requesting a review
- [x] My code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My code fulfills all acceptance criteria
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [ ] I have made corresponding changes to the documentation
- [ ] I have added explanation of architectural decision and rationales to [wiki/adr](https://github.com/IT-REX-Platform/wiki/tree/main/adr)
- [ ] I have updated the changes in the ticket description

## Checklist for reviewer
- [ ] The code works and does not throw errors
- [ ] The code is easy to understand and there are no confusing parts
- [ ] The code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] The code change accomplishes what it is supposed to do
- [ ] I cannot think of any use case in which the code does not behave as intended
- [ ] The added and existing tests reasonably cover the code change
- [ ] I cannot think of any test cases, input or edge cases that should be tested in addition
- [ ] Description of the change is included in the documentation
