### PR TITLE
Adapt courses query to new name

### DIFF
--- a/additionalTypeDefs/user.graphqls
+++ b/additionalTypeDefs/user.graphqls
@@ -15,7 +15,7 @@ extend type CourseMembership {
     course: Course! @resolveTo(
         sourceName: "CourseService",
         sourceTypeName: "Query",
-        sourceFieldName: "coursesById",
+        sourceFieldName: "coursesByIds",
         keyField: "courseId",
         keysArg: "ids"
     )


### PR DESCRIPTION
## Description of changes
Name of query coursesById was changed to coursesByIds. Change gateway to use new name
  
## How has this been tested?
Please describe the test strategy you followed.

- [ ] automated unit test
- [ ] automated integration test
- [ ] automated acceptance test
- [x] manual, exploratory test

Execute query: It should not fail

```graphql
query {
  currentUserInfo {
    userName,
    courseMemberships {
      course {
        title
      }
    }
  }
}
```


## Checklist before requesting a review
- [ ] My code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My code fulfills all acceptance criteria
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [ ] I have made corresponding changes to the documentation
- [ ] I have added explanation of architectural decision and rationales to [wiki/adr](https://github.com/IT-REX-Platform/wiki/tree/main/adr)
- [ ] I have updated the changes in the ticket description

## Checklist for reviewer
- [ ] The code works and does not throw errors
- [ ] The code is easy to understand and there are no confusing parts
- [ ] The code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] The code change accomplishes what it is supposed to do
- [ ] I cannot think of any use case in which the code does not behave as intended
- [ ] The added and existing tests reasonably cover the code change
- [ ] I cannot think of any test cases, input or edge cases that should be tested in addition
- [ ] Description of the change is included in the documentation
