### PR TITLE
ResourceMarkdown integration

### DIFF
--- a/.meshrc.yaml
+++ b/.meshrc.yaml
@@ -49,6 +49,7 @@ additionalTypeDefs:
   - "./additionalTypeDefs/content.graphqls"
   - "./additionalTypeDefs/rewards.graphqls"
   - "./additionalTypeDefs/user.graphqls"
+  - "./additionalTypeDefs/ResourceMarkdown.graphqls"
 additionalResolvers:
   - "./additionalResolvers/user.ts"
   - "./additionalResolvers/content.ts"

--- a/additionalTypeDefs/ResourceMarkdown.graphqls
+++ b/additionalTypeDefs/ResourceMarkdown.graphqls
@@ -1,0 +1,13 @@
+extend type ResourceMarkdown {
+    """
+    Resolved MediaRecords referenced in the ResourceMarkdown text in order.
+    A MediaRecord might be NULL if the referenced MediaRecord no longer exists. 
+    """
+    referencedMediaRecords: [MediaRecord]! @resolveTo(
+        sourceName: "MediaService",
+        sourceTypeName: "Query",
+        sourceFieldName: "mediaRecordsByIds",
+        keyField: "referencedMediaRecordIds",
+        keysArg: "ids"
+    )
+}

--- a/additionalTypeDefs/ResourceMarkdown.graphqls
+++ b/additionalTypeDefs/ResourceMarkdown.graphqls
@@ -6,7 +6,7 @@ extend type ResourceMarkdown {
     referencedMediaRecords: [MediaRecord]! @resolveTo(
         sourceName: "MediaService",
         sourceTypeName: "Query",
-        sourceFieldName: "mediaRecordsByIds",
+        sourceFieldName: "findMediaRecordsByIds",
         keyField: "referencedMediaRecordIds",
         keysArg: "ids"
     )


### PR DESCRIPTION
## Description of changes
Please provide a short description of the change or if the change is sufficiently described in the GitHub issue, provide a link to the issue.

  
## How has this been tested?
Please describe the test strategy you followed.

- [ ] automated unit test
- [ ] automated integration test
- [ ] automated acceptance test
- [x] manual, exploratory test

Tested querying the new field ResourceMarkdown->referencedMediaRecords
    
## Checklist before requesting a review
- [x] My code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My code fulfills all acceptance criteria
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [x] I have made corresponding changes to the documentation
- [ ] I have added explanation of architectural decision and rationales to [wiki/adr](https://github.com/IT-REX-Platform/wiki/tree/main/adr)
- [ ] I have updated the changes in the ticket description

## Checklist for reviewer
- [ ] The code works and does not throw errors
- [ ] The code is easy to understand and there are no confusing parts
- [ ] The code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] The code change accomplishes what it is supposed to do
- [ ] I cannot think of any use case in which the code does not behave as intended
- [ ] The added and existing tests reasonably cover the code change
- [ ] I cannot think of any test cases, input or edge cases that should be tested in addition
- [ ] Description of the change is included in the documentation
